### PR TITLE
[30기 노유정][footer] Fix : footer css 최종수정

### DIFF
--- a/src/components/Footer/Footer.scss
+++ b/src/components/Footer/Footer.scss
@@ -7,7 +7,7 @@
   .inner {
     height: 265px;
     width: 1200px;
-    padding: 50px 0 30px 165px;
+    padding: 50px 0 30px 0;
     margin: 0 auto;
     display: block;
     list-style: disc;
@@ -29,7 +29,7 @@
     .guide {
       ul {
         height: 51px;
-        width: 2100px;
+        width: 1200px;
         display: flex;
         flex-direction: row;
       }


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [x] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
1차 스프린트
- 공통으로 사용할 컴포넌트 Footer 구현

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
 1.공통으로 사용할 컴포넌트 Footer 구현
-  Footer상단의 Link를 통하여 각 페이지로 이동 (추 후 페이지 이동경로 추가 할 예정 Home만 메인의 '/'로 설정 
- 중간 수정부분으로 중복되는 ul+li를 map메서드를 사용하여 간소화 (footerData.js footerList.js footerItem.js 생성)

- 이미지
![Footer Img1](https://user-images.githubusercontent.com/96294372/156216663-7a532ef7-3b4e-4c7b-a1a4-348704c518de.PNG)



<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- map생각보다 재밌다. 깨달음을 얻어 굉장히 신나는데 이걸 다른곳에도 잘 사용할 수 있을지 조금은 걱정이 됩니다..... 그래도 조금이나마 map사용에대한 즐거움을 얻어 저는 그걸로 충분합니다...(또륵)
-merge이후 추가적으로 수정할 부분 수정하면서 모든 브랜치가 전부 merge된 이후에 부분부분 안맞는 css를 수정하면서 충돌이 이런 느낌이구나 라는걸 알게되었습니다
<br />

## :: 기타 질문 및 특이 사항
-companyInfo에도 map메서드를 사용했는데 footerItem.js와 다른 footerList.js컴포넌트를 새로 만들어 넣어주었는데(Link를 사용하지 않고 span을 사용해서 따로 만들어주었습니다!)
 footerItem.js에 같이 사용 할 수 있는 방법은 따로 없나요? 제가 맞게 한 건지 잘 모르겠습니다 ㅠ
